### PR TITLE
Pa11y implementation + Travis configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 
 # Static files
 *.css
+node_modules/
+npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "2.7"
+
+install:
+  - make requirements
+
+script:
+  - make validate

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,22 @@
+help:
+	@echo "Syntax: \`make <target>\` where <target> is one of these:"
+	@echo "  help                          display this help manual"
+	@echo "  requirements                  install requirements"
+	@echo "  static                        build static files"
+	@echo "  validate_accessibilty         run accessibility tests"
+	@echo "  validate                      run all tests"
+	@echo ""
+
 requirements:
 	pip install -r requirements.txt
+	npm install
 
 static:
 	python scripts/compile_sass.py
+
+validate_accessibilty:
+	for file in google_maps/public/html/*.html; do \
+		pa11y -s WCAG2AA file://$(PWD)/$$file; \
+	done
+
+validate: validate_accessibilty

--- a/pa11y.json
+++ b/pa11y.json
@@ -1,0 +1,6 @@
+{
+    "ignore": [
+        "WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.1.NoTitleEl",
+        "WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   },
   "homepage": "https://github.com/ExtensionEngine/xblock-google-maps",
   "devDependencies": {
-    "pa11y": "^4.6.0"
+    "pa11y": "4.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "xblock-google-maps",
+  "version": "1.0.0",
+  "description": "XBlock that allows embedding Google Maps into an edX course",
+  "main": "index.js",
+  "scripts": {},
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ExtensionEngine/xblock-google-maps"
+  },
+  "author": "ExtensionEngine",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ExtensionEngine/xblock-google-maps/issues"
+  },
+  "homepage": "https://github.com/ExtensionEngine/xblock-google-maps",
+  "devDependencies": {
+    "pa11y": "^4.6.0"
+  }
+}


### PR DESCRIPTION
[Pa11y](https://github.com/pa11y/pa11y) seems to be a good starting point for automated accessibility testing. I'm setting it up to traverse through the HTML files and test each of them individually. Travis will fail on explicit errors and not on warnings and notices for now. 
I've explicitly set the standard to WCAG2AA since it is the [required level for edX](https://www.edx.org/accessibility). Since the HTML files are partial templates they don't have the page title and language set up so I've added those two to the ignore list with the premise that they are already set on the platform. More about them here:
http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/2_4_2
http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/3_1_1

Travis setup ticket: https://trello.com/c/YQXn3rYm
Accessibility setup: https://trello.com/c/i79LIC6N